### PR TITLE
Adding --talk-name=org.freedesktop.Flatpak

### DIFF
--- a/org.siril.Siril.json
+++ b/org.siril.Siril.json
@@ -16,7 +16,7 @@
         "--socket=wayland",
         "--filesystem=host",
         /* For spawning OS-native processes */
-        /*"--talk-name=org.freedesktop.Flatpak", */
+        "--talk-name=org.freedesktop.Flatpak",
         /* Needed for gvfs to work */
         "--talk-name=org.gtk.vfs.*",
         "--filesystem=xdg-run/gvfs",


### PR DESCRIPTION
Add the --talk-name=org.freedesktop.Flatpak permission, which permits the use of flatpak-spawn --host