### PR TITLE
wcslib: url changed

### DIFF
--- a/org.siril.Siril.json
+++ b/org.siril.Siril.json
@@ -255,7 +255,7 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://www.atnf.csiro.au/people/mcalabre/WCS/wcslib-8.3.tar.bz2",
+                    "url": "https://www.atnf.csiro.au/computing/software/wcs/wcslib-releases/wcslib-8.3.tar.bz2",
                     "sha256": "431ea3417927bbc02b89bfa3415dc0b4668b0f21a3b46fb8a3525e2fcf614508"
                 }
             ]


### PR DESCRIPTION
The previous URL is 404. Same archive.