### PR TITLE
Cleanup rules

### DIFF
--- a/org.siril.Siril.json
+++ b/org.siril.Siril.json
@@ -4,7 +4,6 @@
     "runtime-version": "49",
     "sdk": "org.gnome.Sdk",
     "command": "siril",
-    "rename-icon": "org.siril.Siril",
     "rename-mime-file": "siril.xml",
     "rename-mime-icons": [
         "text-x-seq"


### PR DESCRIPTION
Remove the development files (including static libs)
This reduce the package size by 102MB.

Includes #17 (required to build)